### PR TITLE
Update for Relaxed KDTree to be compatible with C++20

### DIFF
--- a/src/spatial/bits/spatial_relaxed_kdtree.hpp
+++ b/src/spatial/bits/spatial_relaxed_kdtree.hpp
@@ -179,10 +179,8 @@ namespace spatial
       typedef std::reverse_iterator<const_iterator>   const_reverse_iterator;
 
     private:
-      typedef typename Alloc::template rebind
-      <Relaxed_kdtree_link<Key, Value> >::other       Link_allocator;
-      typedef typename Alloc::template rebind
-      <value_type>::other                             Value_allocator;
+      typedef typename std::allocator_traits<Alloc>::template rebind_alloc<Relaxed_kdtree_link<Key, Value>> Link_allocator;
+      typedef typename std::allocator_traits<Alloc>::template rebind_alloc<value_type> Value_allocator;
 
       // The types used to deal with nodes
       typedef typename mode_type::node_ptr            node_ptr;
@@ -291,7 +289,8 @@ namespace spatial
       {
         safe_allocator safe(get_link_allocator());
         // the following may throw. But we have RAII on safe_allocator
-        get_value_allocator().construct(mutate_pointer(&safe.link->value),
+        auto alloc = get_value_allocator();
+        std::allocator_traits<Value_allocator>::construct(alloc, mutate_pointer(&safe.link->value),
                                         value);
         link_ptr node = safe.release();
         // leave parent uninitialized: its value will change during insertion.
@@ -315,7 +314,8 @@ namespace spatial
       void
       destroy_node(node_ptr node)
       {
-        get_value_allocator().destroy(mutate_pointer(&value(node)));
+        auto alloc = get_value_allocator();
+        std::allocator_traits<Value_allocator>::destroy(alloc, mutate_pointer(&value(node)));
         get_link_allocator().deallocate(link(node), 1);
       }
 


### PR DESCRIPTION
Similar updates as was done by [path](https://github.com/Roboauto/spatial/commit/037a01fa3ca1380a53507284bc238eb9773137f5) is also necessary for Relaxed KDTree.